### PR TITLE
Bars arent created after pushing surfaces

### DIFF
--- a/RFEM_Adapter/RFEM5Adapter.cs
+++ b/RFEM_Adapter/RFEM5Adapter.cs
@@ -91,7 +91,7 @@ namespace BH.Adapter.RFEM5
                 {typeof(RigidLink), new List<Type> { typeof(LinkConstraint), typeof(Node) } },
                 {typeof(FEMesh), new List<Type> { typeof(ISurfaceProperty), typeof(Node) } },
                 {typeof(ISurfaceProperty), new List<Type> { typeof(IMaterialFragment) } },
-                {typeof(Panel), new List<Type> { typeof(ISurfaceProperty) } },
+                {typeof(Panel), new List<Type> { typeof(ISurfaceProperty), typeof(Bar) } },
                 {typeof(ILoad), new List<Type> { typeof(Loadcase) } },
                 {typeof(LoadCombination), new List<Type> { typeof(Loadcase) } }
 


### PR DESCRIPTION
 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->
When first pushing Panels and Bars initially the Bars were not pushed. 
After merging this changes this problem should have been fixed. 

 Closes #176 


 <!-- Add short description of what has been fixed -->


 ### Test files
<!-- Link to test files to validate the proposed changes -->
[Test File](https://burohappold-my.sharepoint.com/:u:/p/arne_martensen/EcAgyj725QZLqyWZtWrnfvQBlPwb_U3CucYxE5sS6oJCkg?e=v7F9Cg)

 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Manipulated the order in which Panels and Bars are written using the dependencies in the RFEM6 adapter
