### PR TITLE
Implement Adapter_Engine method for GetActiveObject

### DIFF
--- a/RFEM_Adapter/RFEM5Adapter.cs
+++ b/RFEM_Adapter/RFEM5Adapter.cs
@@ -124,7 +124,7 @@ namespace BH.Adapter.RFEM5
                 {
                     try
                     {
-                        app = Marshal.GetActiveObject("RFEM5.Application") as rf.IApplication;
+                        app = Engine.Adapter.Query.GetActiveObject("RFEM5.Application") as rf.IApplication;
 
                         app.LockLicense();
                         lockLevel = 1;


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->
https://github.com/BHoM/BHoM_Adapter/pull/398
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #196 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
[Installer](https://burohappold.sharepoint.com/:f:/s/BHoM/EngdHnX9w_5Jr0c2sk7UwmkBUM7VocNTlrLZjH2NZEYk4A?e=oLkZBp)

As a minimum test for each adapter:
1. Run the adapter in Rhino 8;
2. Push a `Bar`;
3. Run an `Execute` method;
4. Pull a result.

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Implemented `GetActiveObject` method from the BHoM_Adapter to allow the toolkit to work in .NET Core environments such as Rhino 8.

### Additional comments
<!-- As required -->